### PR TITLE
Upgraded `@opuscapita/format-utils` version & Fixed currency `editFor…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 * In general follow (https://docs.npmjs.com/getting-started/semantic-versioning) versioning.
 
 ## <next>
+* Upgraded `@opuscapita/format-utils` version
+* Fixed currency `editFormatter`, invalid input is changed to 0
 
 ## 1.2.0
 * Added `onBlur` prop for both `FormattedInput` and `FormattedInputCurrency`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1278,9 +1278,9 @@
       "dev": true
     },
     "@opuscapita/format-utils": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@opuscapita/format-utils/-/format-utils-2.1.1.tgz",
-      "integrity": "sha512-jFVR+6wLc8lnjI2jkvTXT6QXgi+eE0EIktmE+SjlRExtQI8gFHaR1hCXwvrpsDiLTPLZJPdY6yyCA2lkQRfGKg=="
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@opuscapita/format-utils/-/format-utils-2.2.1.tgz",
+      "integrity": "sha512-PVJa2QZU/gFZeJFQFhlpjhouVzGOZngbinMk5x5+0W4vpGR3xM8cDBGbxeDCJr55gH7bD/8QKjMIhPkQbdXNFQ=="
     },
     "@reach/router": {
       "version": "1.2.1",

--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     "write-file-webpack-plugin": "4.5.0"
   },
   "dependencies": {
-    "@opuscapita/format-utils": "2.1.2"
+    "@opuscapita/format-utils": "2.2.1"
   },
   "repository": {
     "type": "git",

--- a/src/formatted-input-currency.component.jsx
+++ b/src/formatted-input-currency.component.jsx
@@ -60,6 +60,10 @@ class FormattedInputCurrency extends React.PureComponent {
 
     const value = formatCurrencyAmount(val, { decimals, thousandSeparator, decimalSeparator });
 
+    if (Number.isNaN(value)) {
+      return formatCurrencyAmount(0, { decimals, thousandSeparator, decimalSeparator });
+    }
+
     if (decimalSeparatorIndex > -1 && decimals === 0) return `${value}${decimalSeparator}`;
 
     return value;


### PR DESCRIPTION
…matter`, invalid input is changed to 0